### PR TITLE
Changes to the galax_pay tables performed

### DIFF
--- a/config/galax_pay.php
+++ b/config/galax_pay.php
@@ -113,10 +113,10 @@ return [
      */
 
     'galax_pay_clients' => [
-        'model'      => \JosanBr\GalaxPay\Models\GalaxPayClient::class,
+        'ref'        => \JosanBr\GalaxPay\Models\GalaxPayClient::class,
         // Columns
-        'entity'     => 'entity',
-        'entity_id'  => 'entity_id',
+        'model'      => 'model',
+        'model_id'   => 'model_id',
         'galax_id'   => 'galax_id',
         'galax_hash' => 'galax_hash',
     ],
@@ -131,7 +131,7 @@ return [
     */
 
     'galax_pay_sessions' => [
-        'model'        => \JosanBr\GalaxPay\Models\GalaxPaySession::class,
+        'ref'          => \JosanBr\GalaxPay\Models\GalaxPaySession::class,
         // Columns
         'scope'        => 'scope',
         'expires_in'   => 'expires_in',

--- a/database/migrations/create_galax_pay_clients_table.php.stub
+++ b/database/migrations/create_galax_pay_clients_table.php.stub
@@ -16,11 +16,11 @@ class CreateGalaxPayClientsTable extends Migration
         Schema::create('galax_pay_clients', function (Blueprint $table) {
             $table->integer('id', true, true);
 
-            $table->string('entity');
-            $table->integer('entity_id');
+            $table->string('model');
+            $table->string('model_id');
 
-            $table->string('galax_id');
-            $table->string('galax_hash');
+            $table->string('galax_id')->unique();
+            $table->string('galax_hash')->unique();
             $table->timestamps();
         });
     }

--- a/database/migrations/create_galax_pay_registrations_table.php.stub
+++ b/database/migrations/create_galax_pay_registrations_table.php.stub
@@ -15,6 +15,7 @@ class CreateGalaxPayRegistrationsTable extends Migration
     {
         Schema::create('galax_pay_registrations', function (Blueprint $table) {
             $table->integer('id', true, true);
+            $table->string('galax_id', 15);
             $table->string('model');
             $table->string('model_id');
             $table->string('my_id')->comment('Your id on galax pay');

--- a/src/Models/GalaxPayClient.php
+++ b/src/Models/GalaxPayClient.php
@@ -6,12 +6,13 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property int $id
- * @property string $entity
- * @property int $entity_id
+ * @property string $model
+ * @property string $model_id
  * @property string $galax_id
  * @property string $galax_hash
  * @property string $created_at
  * @property string $updated_at
+ * @property GalaxPayRegistration[] $galaxPayRegistrations
  * @property GalaxPaySession $galaxPaySession
  */
 class GalaxPayClient extends Model
@@ -19,7 +20,30 @@ class GalaxPayClient extends Model
     /**
      * @var array
      */
-    protected $fillable = ['entity', 'entity_id', 'galax_id', 'galax_hash', 'created_at', 'updated_at'];
+    protected $fillable = ['model', 'model_id', 'galax_id', 'galax_hash', 'created_at', 'updated_at'];
+
+    /**
+     * The "booting" method of the model.
+     *
+     * @return void
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function (GalaxPayClient $galaxPayClient) {
+            if (empty($galaxPayClient->model))
+                $galaxPayClient->model = config('galax_pay.galax_pay_clients.ref');
+        });
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function galaxPayRegistrations()
+    {
+        return $this->hasMany(GalaxPayRegistration::class, 'galax_id');
+    }
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne

--- a/src/Models/GalaxPayRegistration.php
+++ b/src/Models/GalaxPayRegistration.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property int $id
+ * @property string $galax_id
  * @property string $model
  * @property string $model_id
  * @property string $my_id
@@ -18,7 +19,30 @@ class GalaxPayRegistration extends Model
     /**
      * @var array
      */
-    protected $fillable = ['model', 'model_id', 'my_id', 'galax_pay_id', 'created_at', 'updated_at'];
+    protected $fillable = ['galax_id', 'model', 'model_id', 'my_id', 'galax_pay_id', 'created_at', 'updated_at'];
+
+    /**
+     * The "booting" method of the model.
+     *
+     * @return void
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function (GalaxPayRegistration $galaxPay) {
+            if (empty($galaxPay->galax_id))
+                $galaxPay->galax_id = config('galax_pay.credentials.client.id');
+        });
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function galaxPayClient()
+    {
+        return $this->belongsTo(GalaxPayClient::class, 'galax_id');
+    }
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo

--- a/tests/DatabaseSession/GalaxPayTest.php
+++ b/tests/DatabaseSession/GalaxPayTest.php
@@ -19,10 +19,10 @@ class GalaxPayTest extends TestCase
     private function createGalaxPayClient()
     {
         return \JosanBr\GalaxPay\Models\GalaxPayClient::create([
-            'entity_id' => 1,
+            'model_id' => 1,
+            'model' => \JosanBr\GalaxPay\Models\GalaxPayClient::class,
             'galax_id' => 5473,
             'galax_hash' => '83Mw5u8988Qj6fZqS4Z8K7LzOo1j28S706R0BeFe',
-            'entity' => \JosanBr\GalaxPay\Models\GalaxPayClient::class
         ]);
     }
 


### PR DESCRIPTION
### Changes

1. The galax_pay_client table: columns with prefix 'entity' renamed to 'model' and columns 'galax_id' and 'galax_hash' are now unique;

2. The galax_pay_registrations table: added galax_id column, this column refers to a register in the galax_pay_client table.

3. Updated models to reflect changes to their respective tables.

4. Added boot method to templates to insert default values at DB registration time.